### PR TITLE
Feat:#8-상세 조회 기본 구현 Role에 따른 조회 구현 안 됨

### DIFF
--- a/http/challenge.http
+++ b/http/challenge.http
@@ -1,1 +1,5 @@
 GET 'http://localhost:3100/api/challenges?page=1&limit=5&field=Next,API&type=Document'
+
+###
+
+GET 'http://localhost:3100/api/challenges/1'

--- a/src/controllers/challengeController.js
+++ b/src/controllers/challengeController.js
@@ -25,3 +25,15 @@ export const getChallenges = asyncHandler(async (req, res) => {
     throw new Error(e);
   }
 });
+
+export const getChallengeById = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const challenge = await challengeService.getById(id);
+    res.json(challenge);
+  } catch (e) {
+    console.error(e);
+    throw new Error(e);
+  }
+});

--- a/src/repositories/challengeRepository.js
+++ b/src/repositories/challengeRepository.js
@@ -2,16 +2,10 @@ import prisma from "../config/prisma.js";
 
 async function get({ where, skip, take }) {
   return await prisma.challenge.findMany({
-    where: {
-      ...where,
-      applications: {
-        some: {
-          status: "Accepted",
-        }
-      }
-    },
+    where,
     skip,
-    take
+    take,
+    orderBy: { deadLine: "asc" },
   });
 };
 
@@ -30,6 +24,7 @@ async function getById(id) {
         include: {
           user: {
             select: {
+              id: true,
               nickname: true,
               grade: true,
             }

--- a/src/repositories/challengeRepository.js
+++ b/src/repositories/challengeRepository.js
@@ -2,7 +2,14 @@ import prisma from "../config/prisma.js";
 
 async function get({ where, skip, take }) {
   return await prisma.challenge.findMany({
-    where,
+    where: {
+      ...where,
+      applications: {
+        some: {
+          status: "Accepted",
+        }
+      }
+    },
     skip,
     take
   });
@@ -12,4 +19,31 @@ async function count({ where }) {
   return await prisma.challenge.count({ where });
 };
 
-export default { get, count };
+async function getById(id) {
+  return await prisma.challenge.findUnique({
+    where: { id: parseInt(id, 10) },
+    include: {
+      /* to-do: 챌린지를 신청한 User, Admin만 
+                Accepted가 아닌 상태에서 조회 가능하도록 수정 */
+      applications: { select: { status: true }},
+      works: {
+        include: {
+          user: {
+            select: {
+              nickname: true,
+              grade: true,
+            }
+          },
+          _count: {
+            select: { likes: true },
+          },
+      },
+    },
+    _count: {
+      select: { works: true },
+    },
+  },
+  });
+};
+
+export default { get, count, getById };

--- a/src/routes/challengeRouter.js
+++ b/src/routes/challengeRouter.js
@@ -1,8 +1,9 @@
 import express from 'express';
-import { getChallenges } from '../controllers/challengeController.js';
+import { getChallenges, getChallengeById } from '../controllers/challengeController.js';
 
 const router = express.Router();
 
 router.get('/', getChallenges);
+router.get('/:id', getChallengeById);
 
 export default router;

--- a/src/services/challengeService.js
+++ b/src/services/challengeService.js
@@ -26,4 +26,26 @@ async function get({ page, limit, filters }) {
   return { data: challenges, totalCount };
 };
 
-export default { get };
+async function getById(id) {
+  const challenge = await challengeRepository.getById(id);
+
+  if (!challenge) {
+    throw new Error("Challenge not found");
+  }
+
+  const worksLikeCount = challenge.works.map((work) => ({
+    id: work.id,
+    nickname: work.user.nickname,
+    grade: work.user.grade,
+    likeCount: work._count.likes
+  }));
+
+  return {
+    ...challenge,
+    works: worksLikeCount,
+    workTotalCount: challenge._count.works,
+    _count: undefined
+  };
+}
+
+export default { get, getById };

--- a/src/services/challengeService.js
+++ b/src/services/challengeService.js
@@ -15,7 +15,8 @@ async function get({ page, limit, filters }) {
           { title: { contains: keyword, mode: "insensitive" } },
           { description: { contains: keyword, mode: "insensitive" } }
         ]
-      } : {}
+      } : {},
+      { applications: { some: { status: "Accepted" } } },
     ]
   };
 


### PR DESCRIPTION
#### 현재 작업
- 전체 리스트 조회에서 application의 status가 Accepted가 아닌 게시글은 보이지 않도록 수정
- 상세 조회 구현
  - 조회 예시(`http://localhost:3100/api/challenges/1`) 
   ```json
      {
        "id": 1,
        "title": "Next.js Workshop",
        "field": "Next",
        "docType": "Document",
        "docUrl": "http://example.com/doc1",
        "deadLine": "2024-12-01T23:59:59.000Z",
        "description": "Next.js workshop for beginners.",
        "progress": false,
        "participants": 3,
        "maxParticipants": 5,
        "applications": [
            {
                "status": "Waiting"
            }
        ],
        "works": [
            {
                "id": 1,
                "nickname": "nick1",
                "grade": "Amateur",
                "likeCount": 0
            }
        ],
        "workTotalCount": 1
    }
    ```

#### 이후 작업
- 상세 조회에서 챌린지의 상태가 Accepted가 아닌 것은 챌린지를 신청한 user와 Admin만 접근 가능하도록 할 것
  - 다른 User의 접근 시 권한 없음