### PR TITLE
신규 챌린지 승인 및 거절 구현

### DIFF
--- a/src/controllers/applicationController.js
+++ b/src/controllers/applicationController.js
@@ -29,7 +29,7 @@ export const getApplicationById = asyncHandler(async (req, res) => {
   };
 
   if (testAdmin.role !== "Admin") {
-    res.status(403).json({ message: "권한이 없습니다." });
+    return res.status(403).json({ message: "권한이 없습니다." });
   };
 
   try {
@@ -43,6 +43,7 @@ export const getApplicationById = asyncHandler(async (req, res) => {
 
 export const patchApplication = asyncHandler(async (req, res) => {
   const { id } = req.params;
+  const { status, invalidationComment } = req.body;
   const user = req.user;
   const testAdmin = {
     id: 2,
@@ -50,14 +51,19 @@ export const patchApplication = asyncHandler(async (req, res) => {
   };
 
   if (testAdmin.role !== "Admin") {
-    res.status(403).json({ message: "권한이 없습니다." });
+    return res.status(403).json({ message: "권한이 없습니다." });
+  }
+
+  if (!["Accepted", "Rejected"].includes(status)) {
+    return res.status(400).json({ message: "유효하지 않은 상태입니다." });
   }
 
   try {
-    const application = await applicationService.update(id);
+    const application = await applicationService.update(parseInt(id), { status, invalidationComment });
+    res.json(application);
   } catch (e) {
     console.error(e);
-    throw new Error(e);
+    res.status(500).json({ message: e.message });
   }
 })
 

--- a/src/repositories/applicationRepository.js
+++ b/src/repositories/applicationRepository.js
@@ -27,4 +27,15 @@ async function create(data) {
   return await prisma.application.create({ data });
 };
 
-export default { get, findById, count, create };
+async function update(id, data) {
+  return await prisma.application.update({ 
+    where: { id: id },
+    data: {
+      status: data.status,
+      invalidationComment: data.invalidationComment || null,
+      invalidatedAt: data.invalidationComment ? new Date() : null,
+    },
+  });
+}
+
+export default { get, findById, count, create, update };

--- a/src/services/applicationService.js
+++ b/src/services/applicationService.js
@@ -32,6 +32,24 @@ async function get({ page, limit, filters }) {
 
 async function getById(id) {
   return await applicationRepository.findById(parseInt(id));
+};
+
+async function update(id, data) {
+  const application = await applicationRepository.findById(id);
+
+  if (!application) {
+    throw new Error("신청서를 찾을 수 없습니다.");
+  }
+
+  if (application.status !== "Waiting") {
+    throw new Error("승인 또는 거절 처리를 할 수 없습니다.");
+  }
+
+  if (data.status === "Rejected" && !data.invalidationComment) {
+    throw new Error("거절 사유가 필요합니다.");
+  }
+
+  return await applicationRepository.update(id, data);
 }
 
 async function remove(id, user) {
@@ -54,4 +72,4 @@ async function remove(id, user) {
   return await challengeRepository.remove(application.challengeId);
 }
 
-export default { get, getById, remove };
+export default { get, getById, update, remove };


### PR DESCRIPTION
## 관련 이슈
- close #58 

## 주요 변경 사항
-  스키마 Work: description -> content로 변경
  `npx prisma migrate dev` 필요 자세한 사항 노션의 백엔드 시작 가이드 참고
- 신규 챌린지 승인 및 거절 구현
  - req.body에 status 함께 가야 함 (추후 변경 가능)
  
**승인 시**
  ```json
  {
    "status": "Accepted"
  }
  ```
  **거절 시**
  ```json
  {
    "status": "Rejected",
    "invalidationComment": "거절 사유"
  }
  ```
