### PR TITLE
작업물 수정하기에 제출하기 기능 추가

### DIFF
--- a/http/work.http
+++ b/http/work.http
@@ -60,10 +60,20 @@ Content-Type: application/json
 ### 2. 작업물 수정
 PATCH http://localhost:3100/api/works/30
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzMDQzNTY4LCJleHAiOjE3MzMwNDcxNjh9.wDImcrcRCn-VA5_aFVeehZV5w1V82biDpqotkXVc754
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzMzgzOTg5LCJleHAiOjE3MzMzODc1ODl9.PBopHlebiBalSZT-S7l8fw6cyhddKvKtwKjcB6SqGHc
 
 {
   "content": "[수정] 챌린지 13에 제출한 user3의 번역 작업물의 수정 내용입니다."
+}
+
+### 2. 작업물 수정 및 제출
+PATCH http://localhost:3100/api/works/30
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzMzgzOTg5LCJleHAiOjE3MzMzODc1ODl9.PBopHlebiBalSZT-S7l8fw6cyhddKvKtwKjcB6SqGHc
+
+{
+  "content": "[수정 및 제출] 챌린지 13에 제출한 user3의 번역 작업물의 수정 내용입니다.",
+  "isSubmitted": true
 }
 
 ### 1. admin 로그인

--- a/src/controllers/workController.js
+++ b/src/controllers/workController.js
@@ -25,12 +25,12 @@ export const getWorkDetail = asyncHandler(async (req, res) => {
 });
 
 /*************************************************************************************
- * 작업물 수정
+ * 작업물 수정  (제출 기능 추가)
  * ***********************************************************************************
  */
 export const updateWork = asyncHandler(async (req, res, next) => {
   const { workId } = req.params;
-  const { content } = req.body;
+  const { content, isSubmitted } = req.body;
   const user = req.user;
 
   debugLog('번역 작업물 수정 user', req.user);
@@ -39,14 +39,20 @@ export const updateWork = asyncHandler(async (req, res, next) => {
     throw new NotFoundError('요청에 작업 내용이 없습니다.');
   }
 
-  const updatedWork = await workService.updateWork({ workId, user, content });
+  const updatedWork = isSubmitted
+  ? await workService.submitWorkByUpdate({ workId, user, content }) // 제출 로직
+  : await workService.updateWork({ workId, user, content }); // 수정 로직
 
   return res.status(200).json({
-    message: '작업물이 성공적으로 수정되었습니다.',
+    message: isSubmitted
+      ? '작업물이 성공적으로 제출되었습니다.'
+      : '작업물이 성공적으로 수정되었습니다.',
     work: {
       id: updatedWork.id,
       challengeId: updatedWork.challengeId,
-      content,
+      content: updatedWork.content,
+      submittedAt: updatedWork.submittedAt || null,
+      isSubmitted: updatedWork.isSubmitted || false,
       lastModifiedAt: updatedWork.lastModifiedAt,
     },
   });


### PR DESCRIPTION
## 관련 이슈
- close #{이슈 번호}

## 주요 변경 사항

- 작업물 수정하기 기능에 제출 기능 추가
```
###  작업물 수정
PATCH http://localhost:3100/api/works/30
Content-Type: application/json
Authorization: Bearer {{accessToken}}

{
  "content": "[수정] 챌린지 13에 제출한 user3의 번역 작업물의 수정 내용입니다."
}

###  작업물 수정 및 제출
PATCH http://localhost:3100/api/works/30
Content-Type: application/json
Authorization: Bearer {{accessToken}}

{
  "content": "[수정 및 제출] 챌린지 13에 제출한 user3의 번역 작업물의 수정 내용입니다.",
  "isSubmitted": true
}
```

