### PR TITLE
fix: delete participate when admin deletes work (2)

### DIFF
--- a/http/notificationTest.http
+++ b/http/notificationTest.http
@@ -2,7 +2,7 @@
 ###  Admin 챌린지 승인
 PATCH  http://localhost:3100/api/applications/13
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjYsInJvbGUiOiJBZG1pbiIsImlhdCI6MTczMzQ2Mjg5MSwiZXhwIjoxNzMzNDY2NDkxfQ.itS346bVc0NQJqC45RHu9JfCbM5SMNcMcu-KEs1HJws
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjYsInJvbGUiOiJBZG1pbiIsImlhdCI6MTczMzQ4Nzk1NywiZXhwIjoxNzMzNDkxNTU3fQ.KbdfsZ9nFNIErfoxo2NPvxcr1PAT7rec_9mAqjroiWs
 
 {
   "status": "Accepted"
@@ -15,7 +15,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjYsInJvb
 
 ### 1. 챌린지 참여 (user 3)
 POST http://localhost:3100/api/challenges/13/participations
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzNDYyODc0LCJleHAiOjE3MzM0NjY0NzR9.oahNi1-Vl0yJ_2DFHmBmlsuc1Prncazih5whzkw4yoI
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzNDg3OTgxLCJleHAiOjE3MzM0OTE1ODF9.FCfeYtKGSRg1aRdcZY_NVn2DO0FwFxQTHh4nm9tSIZY
 
 #####################################
 ###  작업물 관련                  ###  
@@ -25,7 +25,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvb
 ### 1. 작업물 제출 (user 3)
 POST http://localhost:3100/api/works
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzNDYyODc0LCJleHAiOjE3MzM0NjY0NzR9.oahNi1-Vl0yJ_2DFHmBmlsuc1Prncazih5whzkw4yoI
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzNDg3OTgxLCJleHAiOjE3MzM0OTE1ODF9.FCfeYtKGSRg1aRdcZY_NVn2DO0FwFxQTHh4nm9tSIZY
 
 {
   "challengeId": 13,
@@ -36,7 +36,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsInJvb
 ### 5. 작업물 삭제 (admin)
 DELETE http://localhost:3100/api/works/30
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjYsInJvbGUiOiJBZG1pbiIsImlhdCI6MTczMzQ2Mjg5MSwiZXhwIjoxNzMzNDY2NDkxfQ.itS346bVc0NQJqC45RHu9JfCbM5SMNcMcu-KEs1HJws
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjYsInJvbGUiOiJBZG1pbiIsImlhdCI6MTczMzQ4Nzk1NywiZXhwIjoxNzMzNDkxNTU3fQ.KbdfsZ9nFNIErfoxo2NPvxcr1PAT7rec_9mAqjroiWs
 
 {
   "message": "관리자가 삭제한 사유입니다."

--- a/src/services/workService.js
+++ b/src/services/workService.js
@@ -335,13 +335,11 @@ async function deleteWork({ workId, user, message }) {
     debugLog('challengeId', challengeId);
 
     // 챌린지 참여 기록 삭제 (prismaClient 사용)
-    // 관리자와 사용자 구분
-    const participateDeleteCondition = isAdmin
-      ? { challengeId }                   // 관리자는 userId 조건을 제외
-      : { challengeId, userId: user.id }; // 일반 사용자는 userId 조건 포함
-
     await prismaClient.participate.deleteMany({
-      where: participateDeleteCondition,
+      where: {
+        challengeId: challengeId,
+        userId: work.user.id, // 작업물을 작성한 사용자
+      },
     });
     
     // 챌린지 참여자 수 1 감소


### PR DESCRIPTION
## 관련 이슈
- close #{이슈 번호}

## 주요 변경 사항
- 관리자가 작업물 삭제시 해당 챌린지의 참가 정보를 모두(?) 삭제하는  오류 수정

